### PR TITLE
Simply usage with bundler

### DIFF
--- a/lib/facebookads.rb
+++ b/lib/facebookads.rb
@@ -1,0 +1,1 @@
+require "facebook_ads"


### PR DESCRIPTION
By default `bundler` will try to require `GEM/lib/GEM.rb` file but unfortunately this gem's name doesn't match the class name and we can add a small workaround to solve the problem.

Similar workaround: https://github.com/kpumuk/meta-tags/blob/master/lib/meta-tags.rb