### PR TITLE
Fix typo

### DIFF
--- a/lib/facebook_ads.rb
+++ b/lib/facebook_ads.rb
@@ -58,7 +58,7 @@ module FacebookAds
   require 'facebook_ads/batch_api/batch'
   require 'facebook_ads/batch_api/batch_proxy'
 
-  # Autoload Ab Objects Helpers
+  # Autoload AdObjects Helpers
   Dir.glob(File.expand_path(File.join(__FILE__, '..', 'facebook_ads', 'ad_objects', 'helpers', '*.rb'))).each do |file|
     class_name = File.basename(file, '.rb').split('_').map(&:capitalize).join.to_sym
     autoload class_name, file


### PR DESCRIPTION
Ab ->
Ad

When ad_objects is a camel case, since it is AdObjects, the space has
also been removed.