### PR TITLE
Fix typo and mixing up fields issue

### DIFF
--- a/examples/create_custom_audience.rb
+++ b/examples/create_custom_audience.rb
@@ -26,4 +26,4 @@ ca = ad_acc.customaudiences.create({
   description: 'CA from API',
 })
 
-ca.add_users(File.read("emails").split.map(&:strip), "EMAIL_SHA256")
+ca.add_user(File.read("emails").split.map(&:strip), "EMAIL_SHA256")

--- a/examples/insights_api_async.rb
+++ b/examples/insights_api_async.rb
@@ -1,0 +1,47 @@
+# Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+#
+# You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+# copy, modify, and distribute this software in source code or binary form for use
+# in connection with the web services and APIs provided by Facebook.
+#
+# As with any software that integrates with the Facebook platform, your use of
+# this software is subject to the Facebook Platform Policy
+# [http://developers.facebook.com/policy/]. This copyright notice shall be
+# included in all copies or substantial portions of the software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require 'dotenv/load'
+require 'facebook_ads'
+
+ad_account = FacebookAds::AdAccount.get('act_<ACT_ID>')
+ad_report_run = ad_account.insights.create(
+  limit: 10,
+  level: 'ad',
+  fields: %w[ad_id ad_name cpc]
+  )
+report_run_id = ad_report_run.attributes[:report_run_id]
+
+timeout = 30
+i = 0
+while true
+  job = JSON.parse(FacebookAds::AdReportRun.get(report_run_id).get.body)
+  p "Job async_percent_completion=>#{job['async_percent_completion']}, async_status=>#{job['async_status']}"
+  break if job['async_percent_completion'].to_i >= 100 && job['async_status'] == 'Job Completed'
+  if i > timeout
+    p 'Async job has timed out'
+    break
+  end
+  i += 1
+  sleep(1.0)
+end
+
+FacebookAds::AdReportRun.get(report_run_id).insights.all.each do |insight|
+  p "insight id: #{insight.ad_id}, name: #{insight.ad_name}, cpc: #{insight.cpc}"
+end
+

--- a/lib/facebook_ads/ad_object.rb
+++ b/lib/facebook_ads/ad_object.rb
@@ -131,7 +131,6 @@ module FacebookAds
       define_method("#{verb}_edge") do |edge_name, params = {}, &block|
         params, options = extract_options(params)
         path = "#{self.id}/#{edge_name}"
-        puts path
         APIRequest.new(verb, path, session: session, params: params, options: options).execute do |api_response|
           @last_api_response = api_response
           block ? block[api_response.result] : api_response

--- a/lib/facebook_ads/ad_object.rb
+++ b/lib/facebook_ads/ad_object.rb
@@ -24,7 +24,7 @@ require 'facebook_ads/helpers/edge_helpers'
 
 module FacebookAds
   class AdObject
-    attr_reader :attributes, :fields, :last_api_response
+    attr_reader :attributes, :internal_fields, :last_api_response
     attr_accessor :deserializer
     attr_accessor :last_saved, :last_destroyed
 
@@ -45,7 +45,7 @@ module FacebookAds
       fields = fields.split(',') if fields.is_a?(String)
       session = args.shift
 
-      self.fields = fields + attributes.keys
+      self.internal_fields = fields + attributes.keys
       self.session = session
     end
 
@@ -90,15 +90,17 @@ module FacebookAds
     end
 
     def fields_as_string
-      @fields.to_a.join(',')
+      @internal_fields.to_a.join(',')
     end
 
-    def fields=(fields)
-      @fields = Set.new((fields.is_a?(String) ? fields.split(',') : fields.map(&:to_s)).map(&:to_sym))
+    # please do not use fields= or @fields as instance variable or setter.
+    # 'fields' is resevered keyword for field name in AdReportRun
+    def internal_fields=(fields)
+      @internal_fields = Set.new((fields.is_a?(String) ? fields.split(',') : fields.map(&:to_s)).map(&:to_sym))
     end
 
     def loaded?
-      (@fields - attributes.keys).empty?
+      (@internal_fields - attributes.keys).empty?
     end
 
     def load!

--- a/lib/facebook_ads/ad_object.rb
+++ b/lib/facebook_ads/ad_object.rb
@@ -131,6 +131,7 @@ module FacebookAds
       define_method("#{verb}_edge") do |edge_name, params = {}, &block|
         params, options = extract_options(params)
         path = "#{self.id}/#{edge_name}"
+        puts path
         APIRequest.new(verb, path, session: session, params: params, options: options).execute do |api_response|
           @last_api_response = api_response
           block ? block[api_response.result] : api_response

--- a/lib/facebook_ads/fields.rb
+++ b/lib/facebook_ads/fields.rb
@@ -58,7 +58,7 @@ module FacebookAds
       def define_writer(name)
         define_method("#{name}=") do |val|
           changes[name] = val
-          @fields.add(name.to_s)
+          @internal_fields.add(name.to_s)
         end
       end
     end

--- a/lib/facebook_ads/fields.rb
+++ b/lib/facebook_ads/fields.rb
@@ -40,9 +40,9 @@ module FacebookAds
 
       def define_reader(name)
         define_method(name) do
-          if !fields.include?(name)
-            fields << name
-            Utils.logger.warn("#{name} not in the fields")
+          if !@internal_fields.include?(name)
+            @internal_fields << name
+            Utils.logger.warn("#{name} not in the internal_fields")
           end
 
           load! unless loaded?

--- a/spec/ad_object_spec.rb
+++ b/spec/ad_object_spec.rb
@@ -16,5 +16,31 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+require 'spec_helper'
+
 RSpec.describe FacebookAds::AdObject do
+  describe '#initialize' do
+    let(:value) { {'foo' => 'bar', 'fields' => []} }
+
+    context 'when no "field :fields" is declared in subclass' do
+      class TestClassWithoutFields < FacebookAds::AdObject; end
+
+      it 'should call instance method fields= once' do
+        expect_any_instance_of(FacebookAds::AdObject).to receive(:fields=).once
+        TestClassWithFields.new(value, value.keys)
+      end
+    end
+
+    context 'when "field :fields" is declared in subclass' do
+      class TestClassWithFields < FacebookAds::AdObject
+        field :fields, { list: 'adreportrun_graph_fields_param' }
+      end
+
+      it 'should call instance method fields= once' do
+        expect_any_instance_of(FacebookAds::AdObject).to receive(:fields=).once
+        TestClassWithoutFields.new(value, value.keys)
+      end
+    end
+  end
+
 end

--- a/spec/ad_object_spec.rb
+++ b/spec/ad_object_spec.rb
@@ -19,27 +19,47 @@
 require 'spec_helper'
 
 RSpec.describe FacebookAds::AdObject do
+  let(:value) { {'foo' => 'bar', 'fields' => []} }
+  subject(:this) { described_class.new(value, value.keys) }
+
   describe '#initialize' do
-    let(:value) { {'foo' => 'bar', 'fields' => []} }
+    subject(:subclass) { TestClass.new(value, value.keys) }
 
     context 'when no "field :fields" is declared in subclass' do
-      class TestClassWithoutFields < FacebookAds::AdObject; end
+      class TestClass < FacebookAds::AdObject; end
 
-      it 'should call instance method fields= once' do
-        expect_any_instance_of(FacebookAds::AdObject).to receive(:fields=).once
-        TestClassWithFields.new(value, value.keys)
+      it 'should call instance method internal_fields= once' do
+        expect_any_instance_of(FacebookAds::AdObject).to receive(:internal_fields=).once
+        expect(subclass.attributes[:foo]).to eq('bar')
+        expect(subclass.attributes[:fields]).to eq([])
       end
     end
 
     context 'when "field :fields" is declared in subclass' do
-      class TestClassWithFields < FacebookAds::AdObject
+      class TestClass < FacebookAds::AdObject
         field :fields, { list: 'adreportrun_graph_fields_param' }
       end
 
       it 'should call instance method fields= once' do
-        expect_any_instance_of(FacebookAds::AdObject).to receive(:fields=).once
-        TestClassWithoutFields.new(value, value.keys)
+        expect_any_instance_of(FacebookAds::AdObject).to receive(:internal_fields=).once
+        expect(subclass.attributes[:foo]).to eq('bar')
+        expect(subclass.attributes[:fields]).to eq([])
       end
+    end
+  end
+
+  describe '#internal_fields=' do
+    subject(:internal_fields) { this.internal_fields = fields; this.internal_fields }
+    context 'when given fields param is comma separated string' do
+      let(:fields) { 'foo,bar' }
+
+      it { expect(internal_fields).to eq(Set.new(%i[foo bar])) }
+    end
+
+    context 'when given fields param is array with string keys' do
+      let(:fields) { %w[foo bar] }
+
+      it { expect(internal_fields).to eq(Set.new(%i[foo bar])) }
     end
   end
 


### PR DESCRIPTION
Issues to be fixed in this PR
- #15 
  Fix issue for mixing `field :fields` and `self.field` (rename `self.fields` and `@fields` to `self.internal_fields` and `@fields`)

- #11 
  Fix typo in `examples/create_custom_audience.rb` (add_users -> add_user)

