### PR TITLE
Fix datetime format issue

### DIFF
--- a/examples/get_adspixels.rb
+++ b/examples/get_adspixels.rb
@@ -1,0 +1,29 @@
+# Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+#
+# You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+# copy, modify, and distribute this software in source code or binary form for use
+# in connection with the web services and APIs provided by Facebook.
+#
+# As with any software that integrates with the Facebook platform, your use of
+# this software is subject to the Facebook Platform Policy
+# [http://developers.facebook.com/policy/]. This copyright notice shall be
+# included in all copies or substantial portions of the software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require 'dotenv/load'
+require 'facebook_ads'
+
+ad_account = FacebookAds::AdAccount.get('act_<ACT_ID>')
+ad_account.adspixels(limit: 10).all.each do |pixel|
+  pixel.stats(fields: 'data,timestamp,aggregation',
+              limit: 1_000,
+              aggregation: 'event').all.each do |stat|
+    p stat
+  end
+end

--- a/lib/facebook_ads/field_types/datetime.rb
+++ b/lib/facebook_ads/field_types/datetime.rb
@@ -26,7 +26,7 @@ module FacebookAds
       def deserialize(value, session = nil)
         case value
           when String
-            DateTime.strptime(value, '%FT%T%:z')
+            ::DateTime.strptime(value, '%FT%T%:z')
           else
             Time.at(value).to_datetime
         end
@@ -34,10 +34,10 @@ module FacebookAds
 
       def serialize(value)
         case value
-          when DateTime, Time
+          when ::DateTime, Time
             value.to_time.to_i
           when String
-            DateTime.parse(value).to_time.to_i
+            ::DateTime.parse(value).to_time.to_i
           else
             value
         end

--- a/lib/facebook_ads/field_types/datetime.rb
+++ b/lib/facebook_ads/field_types/datetime.rb
@@ -26,7 +26,11 @@ module FacebookAds
       def deserialize(value, session = nil)
         case value
           when String
-            ::DateTime.strptime(value, '%FT%T%:z')
+            begin
+              ::DateTime.strptime(value, '%FT%T%:z')
+            rescue ArgumentError
+              ::DateTime.strptime(value, '%FT%T')
+            end
           else
             Time.at(value).to_datetime
         end

--- a/spec/field_types/datetime_spec.rb
+++ b/spec/field_types/datetime_spec.rb
@@ -25,9 +25,17 @@ RSpec.describe FacebookAds::FieldTypes::DateTime do
     subject(:deserialize) { this.deserialize(value) }
 
     context 'when given value is string type' do
-      let(:value) { '2017-08-31T23:59:00-04:00' }
+      context 'with time difference in the value' do
+        let(:value) { '2017-08-31T23:59:00-04:00' }
 
-      it { expect(deserialize).to eq(DateTime.strptime('2017-08-31T23:59:00-04:00', '%FT%T%:z')) }
+        it { expect(deserialize).to eq(DateTime.strptime('2017-08-31T23:59:00-04:00', '%FT%T%:z')) }
+      end
+
+      context 'without time difference in the value' do
+        let(:value) { '2017-08-31T23:59:00' }
+
+        it { expect(deserialize).to eq(DateTime.strptime('2017-08-31T23:59:00', '%FT%T')) }
+      end
     end
 
     context 'when given value is number type' do

--- a/spec/field_types/datetime_spec.rb
+++ b/spec/field_types/datetime_spec.rb
@@ -1,0 +1,67 @@
+# Copyright (c) 2017-present, Facebook, Inc. All rights reserved.
+#
+# You are hereby granted a non-exclusive, worldwide, royalty-free license to use,
+# copy, modify, and distribute this software in source code or binary form for use
+# in connection with the web services and APIs provided by Facebook.
+#
+# As with any software that integrates with the Facebook platform, your use of
+# this software is subject to the Facebook Platform Policy
+# [http://developers.facebook.com/policy/]. This copyright notice shall be
+# included in all copies or substantial portions of the software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+# FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+# IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+require 'spec_helper'
+
+RSpec.describe FacebookAds::FieldTypes::DateTime do
+  subject(:this) { described_class.new }
+
+  describe '#deserialize' do
+    subject(:deserialize) { this.deserialize(value) }
+
+    context 'when given value is string type' do
+      let(:value) { '2017-08-31T23:59:00-04:00' }
+
+      it { expect(deserialize).to eq(DateTime.strptime('2017-08-31T23:59:00-04:00', '%FT%T%:z')) }
+    end
+
+    context 'when given value is number type' do
+      let(:value) { 1504238340 }
+
+      it { expect(deserialize).to eq(DateTime.strptime('2017-08-31T23:59:00-04:00', '%FT%T%:z')) }
+    end
+  end
+
+  describe '#serialize' do
+    subject(:serialize) { this.serialize(value) }
+
+    context 'when given value is String type' do
+      let(:value) { '2017-08-31T23:59:00-04:00' }
+
+      it { expect(serialize).to eq(1504238340) }
+    end
+
+    context 'when given value is Time type' do
+      let(:value) { DateTime.strptime('2017-08-31T23:59:00-04:00', '%FT%T%:z').to_time }
+
+      it { expect(serialize).to eq(1504238340) }
+    end
+
+    context 'when given value is DateTime type' do
+      let(:value) { DateTime.strptime('2017-08-31T23:59:00-04:00', '%FT%T%:z') }
+
+      it { expect(serialize).to eq(1504238340) }
+    end
+
+    context 'when given value is something else' do
+      let(:value) { 1504238340 }
+
+      it { expect(serialize).to eq(1504238340) }
+    end
+  end
+end


### PR DESCRIPTION
Issue to be fixed in this PR
- https://github.com/facebook/facebook-ruby-ads-sdk/issues/19
  Add to parse `%FT%T`format when given date format isn't `%FT%T%:z`
  Add example for getting adspixels

Note
- This PR is based on https://github.com/facebook/facebook-ruby-ads-sdk/pull/18. It will be rebased once https://github.com/facebook/facebook-ruby-ads-sdk/pull/18 has merged.