### PR TITLE
Fix shortcut: `ad_account`

### DIFF
--- a/lib/facebook_ads/helpers/shortcuts.rb
+++ b/lib/facebook_ads/helpers/shortcuts.rb
@@ -23,7 +23,7 @@ module FacebookAds
     end
 
     def ad_account(act_id)
-      act_id = 'act_' + act_id unless id =~ /^act_/
+      act_id = 'act_' + act_id unless act_id =~ /^act_/
       AdAccount.get(act_id)
     end
 


### PR DESCRIPTION
The shortcut `ad_account(act_id)` is broken due to typo.
```
undefined local variable or method `id' for FacebookAds:Module
```

This PR fixes it. Thanks.